### PR TITLE
Enforce RedBeanPHP/FlightPHP coding conventions

### DIFF
--- a/.claude/hooks/validate-tiknix-php.py
+++ b/.claude/hooks/validate-tiknix-php.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Tiknix PHP Code Validator Hook
+
+Validates PHP code against Tiknix/RedBeanPHP/FlightPHP coding standards:
+1. Bean property names should use camelCase (not underscore_case)
+2. Table names should use camelCase (not underscore_case)
+3. R::exec should almost NEVER be used - only in extreme situations
+"""
+
+import json
+import sys
+import re
+
+
+def find_underscore_properties(content):
+    """Find bean properties using underscore_case instead of camelCase."""
+    issues = []
+
+    # Match $bean->property_name or $variable->property_name patterns
+    pattern = r'\$\w+->([\w_]+)\s*='
+
+    for match in re.finditer(pattern, content):
+        prop = match.group(1)
+        # Skip if it's an ID reference, box, or internal property
+        if prop in ['id', 'box', 'meta']:
+            continue
+        # Skip relation properties (ownXList, sharedXList, xownXList)
+        if prop.startswith('own') or prop.startswith('shared') or prop.startswith('xown'):
+            continue
+        # Check if property has underscore (indicating wrong convention)
+        if '_' in prop and not prop.startswith('_'):
+            # Suggest camelCase version
+            camel = re.sub(r'_([a-z])', lambda m: m.group(1).upper(), prop)
+            issues.append(f"Property '{prop}' uses underscore_case. Use camelCase '{camel}' instead - RedBeanPHP auto-converts to underscore in DB.")
+
+    return issues
+
+
+def find_underscore_table_names(content):
+    """Find R::dispense or R::load with underscore table names."""
+    issues = []
+
+    # Match R::dispense('table_name') or R::load('table_name', ...)
+    pattern = r"R::(dispense|load|find|findOne|findAll|count|trash)\s*\(\s*['\"]([^'\"]+)['\"]"
+
+    for match in re.finditer(pattern, content):
+        method = match.group(1)
+        table = match.group(2)
+        if '_' in table:
+            # Suggest camelCase version
+            camel = re.sub(r'_([a-z])', lambda m: m.group(1).upper(), table)
+            issues.append(f"Table name '{table}' in R::{method}() uses underscore. Use camelCase '{camel}' - RedBeanPHP auto-converts to underscore in DB.")
+
+    return issues
+
+
+def find_exec_usage(content):
+    """Find ANY use of R::exec and flag it for review."""
+    issues = []
+
+    # Match R::exec with any SQL statement
+    pattern = r"R::exec\s*\(\s*['\"]([^'\"]+)['\"]"
+
+    for match in re.finditer(pattern, content):
+        sql = match.group(1).strip()
+        sql_upper = sql.upper()
+
+        # Check what type of operation it is
+        if sql_upper.startswith('INSERT'):
+            issues.append(f"R::exec() used for INSERT. This bypasses FUSE models! Use R::dispense() + R::store() instead.")
+        elif sql_upper.startswith('UPDATE'):
+            # Check if it's a simple update that should use beans
+            if 'WHERE' in sql_upper and ('= ?' in sql or '=?' in sql):
+                # Check if it's NOT a complex operation (increment, bulk, etc.)
+                if '+ 1' not in sql and '- 1' not in sql and 'NOW()' not in sql_upper:
+                    issues.append(f"R::exec() used for UPDATE. This bypasses FUSE models! Use R::load() + R::store() instead.")
+                else:
+                    issues.append(f"R::exec() for UPDATE detected. Verify this is truly necessary and cannot be done with beans.")
+            else:
+                issues.append(f"R::exec() for UPDATE detected. Verify this is truly necessary and cannot be done with beans.")
+        elif sql_upper.startswith('DELETE'):
+            issues.append(f"R::exec() used for DELETE. This bypasses FUSE models! Use R::trash() instead.")
+        else:
+            issues.append(f"R::exec() detected. R::exec should ONLY be used in extreme situations. Can this use bean methods instead?")
+
+    return issues
+
+
+def validate_php_code(content):
+    """Run all validations on PHP content."""
+    all_issues = []
+
+    # Skip if not PHP
+    if '<?php' not in content and '<?=' not in content:
+        # Check if it contains PHP-like RedBean code even without <?php tag
+        if 'R::' not in content:
+            return []
+
+    all_issues.extend(find_underscore_properties(content))
+    all_issues.extend(find_underscore_table_names(content))
+    all_issues.extend(find_exec_usage(content))
+
+    return all_issues
+
+
+def main():
+    try:
+        # Read input from stdin (JSON format from Claude Code)
+        input_data = json.load(sys.stdin)
+
+        tool_name = input_data.get('tool_name', '')
+        tool_input = input_data.get('tool_input', {})
+
+        # Only validate Write and Edit operations
+        if tool_name not in ['Write', 'Edit']:
+            sys.exit(0)
+
+        # Get file path and content
+        file_path = tool_input.get('file_path', '')
+
+        # Only validate PHP files
+        if not file_path.endswith('.php'):
+            sys.exit(0)
+
+        # Get the content being written/edited
+        if tool_name == 'Write':
+            content = tool_input.get('content', '')
+        elif tool_name == 'Edit':
+            content = tool_input.get('new_string', '')
+        else:
+            sys.exit(0)
+
+        # Run validations
+        issues = validate_php_code(content)
+
+        if issues:
+            # Format feedback message
+            feedback = "TIKNIX CODE STANDARDS VIOLATION:\n\n"
+            for i, issue in enumerate(issues, 1):
+                feedback += f"{i}. {issue}\n"
+            feedback += "\nSee CLAUDE.md for Tiknix coding standards.\n"
+            feedback += "RedBeanPHP docs: https://redbeanphp.com/"
+
+            # Return JSON with block decision
+            output = {
+                "decision": "block",
+                "reason": feedback
+            }
+            print(json.dumps(output))
+
+        sys.exit(0)
+
+    except json.JSONDecodeError:
+        # If input isn't valid JSON, just pass through
+        sys.exit(0)
+    except Exception as e:
+        # Log error but don't block
+        print(f"Hook error: {e}", file=sys.stderr)
+        sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-tiknix-php.py",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,214 @@
+# Tiknix Development Standards
+
+This project uses FlightPHP and RedBeanPHP. You MUST follow these conventions strictly.
+
+## RedBeanPHP Rules (CRITICAL)
+
+> **Official Documentation**: https://redbeanphp.com/
+> Always refer to the official docs for the most accurate information.
+
+### Naming Conventions (IMPORTANT)
+
+RedBeanPHP automatically converts camelCase in PHP to underscore_case in the database.
+
+**In PHP code, use camelCase:**
+```php
+// Table names - use camelCase (NO underscores)
+$bean = R::dispense('orderItem');     // Creates table: order_item
+$bean = R::dispense('userProfile');   // Creates table: user_profile
+$bean = R::dispense('member');        // Creates table: member
+
+// Column names - use camelCase
+$bean->firstName = 'John';            // Creates column: first_name
+$bean->createdAt = date('Y-m-d');     // Creates column: created_at
+$bean->userId = 5;                    // Creates column: user_id
+```
+
+**WRONG - Don't use underscore_case in PHP:**
+```php
+// WRONG - Don't use underscores in PHP bean code
+$bean = R::dispense('order_item');    // WRONG!
+$bean->first_name = 'John';           // WRONG!
+$bean->created_at = date('Y-m-d');    // WRONG!
+```
+
+### Relations (One-to-Many)
+
+Use `own[BeanType]List` for one-to-many relationships:
+
+```php
+// Parent has many children
+$shop = R::dispense('shop');
+$shop->name = 'My Shop';
+
+$product = R::dispense('product');
+$product->name = 'Vase';
+
+// Add product to shop (creates shop_id foreign key in product table)
+$shop->ownProductList[] = $product;
+R::store($shop);
+
+// Retrieve children
+$products = $shop->ownProductList;
+
+// Use xownProductList for CASCADE DELETE (deletes children when parent deleted)
+$shop->xownProductList[] = $product;
+```
+
+### Relations (Many-to-Many)
+
+Use `shared[BeanType]List` for many-to-many relationships:
+
+```php
+// Products can have many tags, tags can have many products
+$product = R::dispense('product');
+$product->name = 'Widget';
+
+$tag = R::dispense('tag');
+$tag->name = 'Featured';
+
+// Add tag to product (creates product_tag link table automatically)
+$product->sharedTagList[] = $tag;
+R::store($product);
+
+// Retrieve related beans
+$tags = $product->sharedTagList;
+$products = $tag->sharedProductList;
+```
+
+### Foreign Key Naming
+
+Foreign keys are automatically named `[parent_type]_id`:
+- `shop_id` in product table (product belongs to shop)
+- `member_id` in order table (order belongs to member)
+
+### Bean Operations (CRITICAL)
+
+**ALWAYS use bean operations for CRUD. R::exec should ONLY be used in extreme situations where there is no other way to get the data.**
+
+```php
+// CORRECT - Use beans for create
+$member = R::dispense('member');
+$member->email = 'test@example.com';
+$member->createdAt = date('Y-m-d H:i:s');
+R::store($member);
+
+// CORRECT - Use R::load for updates
+$member = R::load('member', $id);
+$member->lastLogin = date('Y-m-d H:i:s');
+R::store($member);
+
+// CORRECT - Use R::findOne for lookups
+$member = R::findOne('member', 'email = ?', [$email]);
+
+// CORRECT - Use R::trash for deletes
+$member = R::load('member', $id);
+R::trash($member);
+// Or: R::trash('member', $id);
+
+// WRONG - NEVER use R::exec for simple CRUD
+R::exec('INSERT INTO member (email) VALUES (?)', [$email]);  // WRONG!
+R::exec('UPDATE member SET email = ? WHERE id = ?', [$email, $id]);  // WRONG!
+R::exec('DELETE FROM member WHERE id = ?', [$id]);  // WRONG!
+```
+
+**The ONLY acceptable uses for R::exec:**
+```php
+// Complex atomic operation that can't be done with beans
+R::exec('UPDATE member SET loginCount = loginCount + 1 WHERE id = ?', [$id]);
+
+// Bulk operations on many records with complex conditions
+R::exec('DELETE FROM session WHERE expiresAt < NOW() AND memberId IN (SELECT id FROM member WHERE isDeleted = 1)');
+```
+
+**If you think you need R::exec, ask yourself:**
+1. Can this be done with R::load + R::store? → Use that instead
+2. Can this be done with R::find + loop + R::store? → Use that instead
+3. Is this a complex aggregate/batch that truly can't use beans? → Only then use R::exec
+
+### Why Bean Operations Are Mandatory
+
+RedBeanPHP models (FUSE) ONLY work with bean operations. Using R::exec bypasses:
+- Model hooks (`update()`, `afterUpdate()`, `delete()`, etc.)
+- Model validation
+- Business logic in models
+- The entire point of using an ORM
+
+If you use R::exec for simple CRUD, the ORM becomes useless and models are ignored.
+
+### Query Methods Reference
+
+| Method | Returns | Use Case |
+|--------|---------|----------|
+| `R::load($type, $id)` | Single bean (empty if not found) | Get by ID |
+| `R::findOne($type, $sql, $params)` | Single bean or NULL | Get first match |
+| `R::find($type, $sql, $params)` | Array of beans | Get matching rows |
+| `R::findAll($type, $sql, $params)` | Array of beans | Same as find |
+| `R::count($type, $sql, $params)` | Integer | Count rows |
+| `R::getAll($sql, $params)` | Array of arrays | Complex SELECT with joins |
+
+### Quick Reference: PHP Property → Database Column
+
+| PHP (camelCase) | Database (auto-converted) |
+|-----------------|---------------------------|
+| `createdAt`     | `created_at`              |
+| `updatedAt`     | `updated_at`              |
+| `firstName`     | `first_name`              |
+| `lastName`      | `last_name`               |
+| `userId`        | `user_id`                 |
+| `orderTotal`    | `order_total`             |
+| `isActive`      | `is_active`               |
+| `ownProductList`| (relation, not a column)  |
+| `sharedTagList` | (relation, not a column)  |
+
+## FlightPHP Rules
+
+### Controller Conventions
+
+1. Controllers extend `BaseControls\Control`
+2. Use `$this->render()` for views
+3. Use `$this->getParam()` for request parameters
+4. Use `$this->sanitize()` for input sanitization
+5. Always validate CSRF with `$this->validateCSRF()` on POST requests
+
+### Response Methods
+
+```php
+// JSON responses
+Flight::jsonSuccess($data, 'Success message');
+Flight::jsonError('Error message', 400);
+
+// Redirects
+Flight::redirect('/path');
+
+// Views
+$this->render('view/name', ['data' => $data]);
+```
+
+### Permission Levels
+
+```php
+LEVELS['ROOT']   = 1    // Super admin
+LEVELS['ADMIN']  = 50   // Administrator
+LEVELS['MEMBER'] = 100  // Regular user
+LEVELS['PUBLIC'] = 101  // Not logged in (guest)
+```
+
+Lower number = higher privilege. Check with `Flight::hasLevel(LEVELS['ADMIN'])`.
+
+## File Structure
+
+```
+/controls       - Controllers (auto-routed by URL)
+/views          - PHP view templates
+/lib            - Core libraries
+/models         - RedBeanPHP FUSE models
+/routes         - Custom route definitions
+/conf           - Configuration files
+```
+
+## See Also
+
+- `REDBEAN_README.md` - Detailed RedBeanPHP reference
+- `FLIGHTPHP_README.md` - Detailed FlightPHP reference
+- https://redbeanphp.com/ - Official RedBeanPHP documentation

--- a/controls/Admin.php
+++ b/controls/Admin.php
@@ -146,8 +146,8 @@ class Admin extends Control {
                         }
                         
                         if (empty($this->viewData['error'])) {
-                            $member->updated_at = date('Y-m-d H:i:s');
-                            
+                            $member->updatedAt = date('Y-m-d H:i:s');
+
                             try {
                                 R::store($member);
                                 $this->viewData['success'] = 'Member updated successfully';
@@ -221,9 +221,9 @@ class Admin extends Control {
                         $member->password = password_hash($password, PASSWORD_DEFAULT);
                         $member->level = $level;
                         $member->status = $status;
-                        $member->created_at = date('Y-m-d H:i:s');
-                        $member->updated_at = date('Y-m-d H:i:s');
-                        
+                        $member->createdAt = date('Y-m-d H:i:s');
+                        $member->updatedAt = date('Y-m-d H:i:s');
+
                         try {
                             R::store($member);
                             $this->logger->info('New member created by admin', [
@@ -313,7 +313,7 @@ class Admin extends Control {
                 
                 if (!$permission->id) {
                     $permission->validcount = 0;
-                    $permission->created_at = date('Y-m-d H:i:s');
+                    $permission->createdAt = date('Y-m-d H:i:s');
                 }
                 
                 try {
@@ -442,7 +442,7 @@ class Admin extends Control {
                         $member = R::load('member', $memberId);
                         if ($member->id && $member->username !== 'public-user-entity') {
                             $member->status = 'active';
-                            $member->updated_at = date('Y-m-d H:i:s');
+                            $member->updatedAt = date('Y-m-d H:i:s');
                             R::store($member);
                             $count++;
                         }
@@ -457,7 +457,7 @@ class Admin extends Control {
                         $member = R::load('member', $memberId);
                         if ($member->id && $member->username !== 'public-user-entity') {
                             $member->status = 'suspended';
-                            $member->updated_at = date('Y-m-d H:i:s');
+                            $member->updatedAt = date('Y-m-d H:i:s');
                             R::store($member);
                             $count++;
                         }

--- a/controls/Auth.php
+++ b/controls/Auth.php
@@ -77,8 +77,8 @@ class Auth extends BaseControls\Control {
             }
             
             // Update last login
-            $member->last_login = date('Y-m-d H:i:s');
-            $member->login_count = ($member->login_count ?? 0) + 1;
+            $member->lastLogin = date('Y-m-d H:i:s');
+            $member->loginCount = ($member->loginCount ?? 0) + 1;
             R::store($member);
             
             // Set session
@@ -203,7 +203,7 @@ class Auth extends BaseControls\Control {
             $member->password = password_hash($password, PASSWORD_DEFAULT);
             $member->level = LEVELS['MEMBER'];
             $member->status = 'active'; // Active immediately - no email verification
-            $member->created_at = date('Y-m-d H:i:s');
+            $member->createdAt = date('Y-m-d H:i:s');
             
             $id = R::store($member);
             
@@ -258,8 +258,8 @@ class Auth extends BaseControls\Control {
             if ($member) {
                 // Generate reset token
                 $token = bin2hex(random_bytes(32));
-                $member->reset_token = $token;
-                $member->reset_expires = date('Y-m-d H:i:s', strtotime('+1 hour'));
+                $member->resetToken = $token;
+                $member->resetExpires = date('Y-m-d H:i:s', strtotime('+1 hour'));
                 R::store($member);
                 
                 // Send reset email (implement your email service)
@@ -350,8 +350,8 @@ class Auth extends BaseControls\Control {
             
             // Update password
             $member->password = password_hash($password, PASSWORD_DEFAULT);
-            $member->reset_token = null;
-            $member->reset_expires = null;
+            $member->resetToken = null;
+            $member->resetExpires = null;
             R::store($member);
             
             $this->logger->info('Password reset completed', ['id' => $member->id]);

--- a/controls/Member.php
+++ b/controls/Member.php
@@ -58,8 +58,8 @@ class Member extends Control {
                 } else {
                     // Update allowed fields
                     $member->email = $email;
-                    $member->first_name = $first_name;
-                    $member->last_name = $last_name;
+                    $member->firstName = $first_name;
+                    $member->lastName = $last_name;
                     $member->bio = $bio;
                 }
             }
@@ -84,7 +84,7 @@ class Member extends Control {
             }
             
             if (empty($this->viewData['error'])) {
-                $member->updated_at = date('Y-m-d H:i:s');
+                $member->updatedAt = date('Y-m-d H:i:s');
                 
                 try {
                     R::store($member);

--- a/controls/Permissions.php
+++ b/controls/Permissions.php
@@ -75,7 +75,7 @@ class Permissions extends BaseControls\Control {
             $auth->method = $method;
             $auth->level = LEVELS['ADMIN']; // Default to admin
             $auth->description = "Auto-generated permission for {$control}:{$method}";
-            $auth->created_at = date('Y-m-d H:i:s');
+            $auth->createdAt = date('Y-m-d H:i:s');
             R::store($auth);
 
             // Clear cache after creating permission
@@ -164,14 +164,14 @@ class Permissions extends BaseControls\Control {
                 }
             } else {
                 $permission = R::dispense('authcontrol');
-                $permission->created_at = date('Y-m-d H:i:s');
+                $permission->createdAt = date('Y-m-d H:i:s');
             }
-            
+
             $permission->control = strtolower($this->sanitize($this->getParam('control')));
             $permission->method = strtolower($this->sanitize($this->getParam('method')));
             $permission->level = (int)$this->getParam('level');
             $permission->description = $this->sanitize($this->getParam('description'));
-            $permission->updated_at = date('Y-m-d H:i:s');
+            $permission->updatedAt = date('Y-m-d H:i:s');
             
             R::store($permission);
 

--- a/database/init_contact.php
+++ b/database/init_contact.php
@@ -24,30 +24,33 @@ try {
     $contact->message = 'This is a test message that can be deleted.';
     $contact->category = 'general';
     $contact->status = 'new';
-    $contact->ip_address = '127.0.0.1';
-    $contact->user_agent = 'CLI/Init';
-    $contact->member_id = null;
-    $contact->created_at = date('Y-m-d H:i:s');
-    $contact->read_at = null;
-    $contact->responded_at = null;
-    $contact->responded_by = null;
-    $contact->updated_at = null;
+    $contact->ipAddress = '127.0.0.1';
+    $contact->userAgent = 'CLI/Init';
+    $contact->memberId = null;
+    $contact->createdAt = date('Y-m-d H:i:s');
+    $contact->readAt = null;
+    $contact->respondedAt = null;
+    $contact->respondedBy = null;
+    $contact->updatedAt = null;
     $id = R::store($contact);
     
     echo "✓ Created contact table\n";
     
     // Create a sample response to force table creation
     $response = R::dispense('contactresponse');
-    $response->contact_id = $id;
-    $response->admin_id = 1;
+    $response->contactId = $id;
+    $response->adminId = 1;
     $response->response = 'Test response';
-    $response->created_at = date('Y-m-d H:i:s');
+    $response->createdAt = date('Y-m-d H:i:s');
     R::store($response);
-    
+
     echo "✓ Created contactresponse table\n";
-    
-    // Clean up test data
-    R::exec('DELETE FROM contactresponse WHERE contact_id = ?', [$id]);
+
+    // Clean up test data using beans
+    $responses = R::find('contactresponse', 'contact_id = ?', [$id]);
+    foreach ($responses as $resp) {
+        R::trash($resp);
+    }
     R::trash($contact);
     
     echo "✓ Cleaned up test data\n";

--- a/database/init_users.php
+++ b/database/init_users.php
@@ -22,8 +22,8 @@ if (!$admin) {
     $admin->password = password_hash('admin123', PASSWORD_DEFAULT); // Change this password!
     $admin->level = 0; // Root level
     $admin->status = 'active';
-    $admin->created_at = date('Y-m-d H:i:s');
-    $admin->updated_at = date('Y-m-d H:i:s');
+    $admin->createdAt = date('Y-m-d H:i:s');
+    $admin->updatedAt = date('Y-m-d H:i:s');
     $adminId = R::store($admin);
     echo "Created admin user with ID: $adminId\n";
     echo "Default password: admin123 (PLEASE CHANGE THIS!)\n";
@@ -40,8 +40,8 @@ if (!$publicUser) {
     $publicUser->password = ''; // No password for public entity
     $publicUser->level = 101; // Public level
     $publicUser->status = 'active'; // Use 'active' instead of 'system'
-    $publicUser->created_at = date('Y-m-d H:i:s');
-    $publicUser->updated_at = date('Y-m-d H:i:s');
+    $publicUser->createdAt = date('Y-m-d H:i:s');
+    $publicUser->updatedAt = date('Y-m-d H:i:s');
     $publicId = R::store($publicUser);
     echo "Created public-user-entity with ID: $publicId\n";
 } else {
@@ -72,7 +72,7 @@ foreach ($permissions as $perm) {
         $authControl->description = $perm['description'];
         $authControl->linkorder = 0;
         $authControl->validcount = 0;
-        $authControl->created_at = date('Y-m-d H:i:s');
+        $authControl->createdAt = date('Y-m-d H:i:s');
         R::store($authControl);
         echo "Created permission: {$perm['control']}/{$perm['method']}\n";
     }

--- a/database/reset_admin_password.php
+++ b/database/reset_admin_password.php
@@ -17,7 +17,7 @@ $admin = R::findOne('member', 'username = ?', ['admin']);
 if ($admin) {
     $newPassword = 'admin123';
     $admin->password = password_hash($newPassword, PASSWORD_DEFAULT);
-    $admin->updated_at = date('Y-m-d H:i:s');
+    $admin->updatedAt = date('Y-m-d H:i:s');
     R::store($admin);
     echo "Admin password reset to: $newPassword\n";
 } else {

--- a/lib/FlightMap.php
+++ b/lib/FlightMap.php
@@ -289,7 +289,7 @@ Flight::map('getSetting', function($key, $memberId = null) {
     }
     
     $setting = R::findOne('settings', 'member_id = ? AND setting_key = ?', [$memberId, $key]);
-    return $setting ? $setting->setting_value : null;
+    return $setting ? $setting->settingValue : null;
 });
 
 Flight::map('setSetting', function($key, $value, $memberId = null) {
@@ -301,11 +301,11 @@ Flight::map('setSetting', function($key, $value, $memberId = null) {
     $setting = R::findOne('settings', 'member_id = ? AND setting_key = ?', [$memberId, $key]);
     if (!$setting) {
         $setting = R::dispense('settings');
-        $setting->member_id = $memberId;
-        $setting->setting_key = $key;
+        $setting->memberId = $memberId;
+        $setting->settingKey = $key;
     }
-    $setting->setting_value = $value;
-    $setting->updated_at = date('Y-m-d H:i:s');
+    $setting->settingValue = $value;
+    $setting->updatedAt = date('Y-m-d H:i:s');
     
     return R::store($setting);
 });

--- a/lib/PermissionCache.php
+++ b/lib/PermissionCache.php
@@ -340,7 +340,7 @@ class PermissionCache {
             $auth->level = LEVELS['ADMIN']; // Default to admin level
             $auth->description = "Auto-generated permission for {$control}::{$method}";
             $auth->validcount = 0;
-            $auth->created_at = date('Y-m-d H:i:s');
+            $auth->createdAt = date('Y-m-d H:i:s');
             R::store($auth);
 
             // Add to local cache immediately

--- a/lib/plugins/GoogleAuth.php
+++ b/lib/plugins/GoogleAuth.php
@@ -203,12 +203,12 @@ class GoogleAuth {
 
         if ($member) {
             // Update last login
-            $member->last_login = date('Y-m-d H:i:s');
-            $member->login_count = ($member->login_count ?? 0) + 1;
+            $member->lastLogin = date('Y-m-d H:i:s');
+            $member->loginCount = ($member->loginCount ?? 0) + 1;
 
             // Update avatar if changed
             if (!empty($googleUser['picture'])) {
-                $member->avatar_url = $googleUser['picture'];
+                $member->avatarUrl = $googleUser['picture'];
             }
 
             R::store($member);
@@ -220,12 +220,12 @@ class GoogleAuth {
 
         if ($member) {
             // Link Google ID to existing account
-            $member->google_id = $googleId;
-            $member->last_login = date('Y-m-d H:i:s');
-            $member->login_count = ($member->login_count ?? 0) + 1;
+            $member->googleId = $googleId;
+            $member->lastLogin = date('Y-m-d H:i:s');
+            $member->loginCount = ($member->loginCount ?? 0) + 1;
 
-            if (!empty($googleUser['picture']) && empty($member->avatar_url)) {
-                $member->avatar_url = $googleUser['picture'];
+            if (!empty($googleUser['picture']) && empty($member->avatarUrl)) {
+                $member->avatarUrl = $googleUser['picture'];
             }
 
             R::store($member);
@@ -240,16 +240,16 @@ class GoogleAuth {
 
         // Create new member
         $member = R::dispense('member');
-        $member->google_id = $googleId;
+        $member->googleId = $googleId;
         $member->email = $email;
         $member->username = self::generateUsername($googleUser);
-        $member->display_name = $googleUser['name'] ?? '';
-        $member->avatar_url = $googleUser['picture'] ?? '';
+        $member->displayName = $googleUser['name'] ?? '';
+        $member->avatarUrl = $googleUser['picture'] ?? '';
         $member->level = LEVELS['MEMBER'] ?? 100;
         $member->status = 'active';
-        $member->created_at = date('Y-m-d H:i:s');
-        $member->last_login = date('Y-m-d H:i:s');
-        $member->login_count = 1;
+        $member->createdAt = date('Y-m-d H:i:s');
+        $member->lastLogin = date('Y-m-d H:i:s');
+        $member->loginCount = 1;
 
         // No password for OAuth users
         $member->password = null;
@@ -301,15 +301,15 @@ class GoogleAuth {
     public static function getMemberGoogleInfo(int $memberId): ?array {
         $member = R::load('member', $memberId);
 
-        if (!$member || empty($member->google_id)) {
+        if (!$member || empty($member->googleId)) {
             return null;
         }
 
         return [
-            'google_id' => $member->google_id,
+            'googleId' => $member->googleId,
             'email' => $member->email,
-            'display_name' => $member->display_name,
-            'avatar_url' => $member->avatar_url
+            'displayName' => $member->displayName,
+            'avatarUrl' => $member->avatarUrl
         ];
     }
 }


### PR DESCRIPTION
## Changes

### Property Naming (camelCase)
- Convert all underscore_case bean properties to camelCase
- RedBeanPHP auto-converts camelCase to underscore_case in database
- Affects: Member, Admin, Auth, Contact, Permissions, GoogleAuth, FlightMap, PermissionCache, and database init scripts

### R::exec Usage
- Replace R::exec DELETE operations with R::find + R::trash loops
- Ensures FUSE model hooks are triggered for all CRUD operations
- Remaining R::exec usage is for legitimate cases only:
  - DDL operations (CREATE INDEX)
  - Atomic increment operations (validcount + 1)

### Claude Code Hooks
- Add CLAUDE.md with Tiknix coding standards
- Add .claude/settings.json with PreToolUse hook
- Add .claude/hooks/validate-tiknix-php.py validation script
- Hooks block code that violates conventions before it's written

## Files Modified (11)
- controls/Admin.php, Auth.php, Contact.php, Member.php, Permissions.php
- lib/FlightMap.php, PermissionCache.php, plugins/GoogleAuth.php
- database/init_contact.php, init_users.php, reset_admin_password.php

## Files Added (3)
- CLAUDE.md
- .claude/settings.json
- .claude/hooks/validate-tiknix-php.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)