### PR TITLE
Add interactive USA map with state detail slide-out

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -19,7 +19,13 @@ class Bootstrap {
     private $logger;
     private $cliHandler;
     
-    public function __construct($configFile = 'conf/config.ini') {
+    public function __construct($configFile = null) {
+        // Default config path relative to this file
+        if ($configFile === null) {
+            $configFile = __DIR__ . '/conf/config.ini';
+        } elseif ($configFile[0] !== '/') {
+            $configFile = __DIR__ . '/' . $configFile;
+        }
         // Initialize autoloader first - this must come before any framework usage
         $this->initAutoloader();
         
@@ -159,8 +165,11 @@ class Bootstrap {
                 $type = $dbConfig['type'] ?? 'mysql';
 
                 if ($type === 'sqlite') {
-                    // SQLite configuration
+                    // SQLite configuration - use absolute path relative to project root
                     $dbPath = $dbConfig['path'] ?? 'database/tiknix.db';
+                    if ($dbPath[0] !== '/') {
+                        $dbPath = __DIR__ . '/' . $dbPath;
+                    }
                     // Create database directory if it doesn't exist
                     $dbDir = dirname($dbPath);
                     if (!is_dir($dbDir)) {

--- a/controls/Map.php
+++ b/controls/Map.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Map Controller
+ * Displays interactive maps
+ */
+
+namespace app;
+
+use \Flight as Flight;
+
+class Map extends BaseControls\Control {
+
+    /**
+     * USA Map page
+     * Displays an interactive map of the United States
+     */
+    public function usa() {
+        $this->render('map/usa', [
+            'title' => 'Map of the USA',
+            'states' => $this->getStatesData()
+        ]);
+    }
+
+    /**
+     * Get state details (AJAX endpoint)
+     */
+    public function stateDetails() {
+        $stateCode = $this->getParam('state', '');
+
+        if (empty($stateCode)) {
+            $this->jsonError('State code required', 400);
+            return;
+        }
+
+        $states = $this->getStatesData();
+        $stateCode = strtoupper($stateCode);
+
+        if (!isset($states[$stateCode])) {
+            $this->jsonError('State not found', 404);
+            return;
+        }
+
+        $state = $states[$stateCode];
+
+        $this->json([
+            'success' => true,
+            'state' => $state
+        ]);
+    }
+
+    /**
+     * Get data for all US states
+     */
+    private function getStatesData(): array {
+        return [
+            'AL' => ['name' => 'Alabama', 'code' => 'AL', 'capital' => 'Montgomery'],
+            'AK' => ['name' => 'Alaska', 'code' => 'AK', 'capital' => 'Juneau'],
+            'AZ' => ['name' => 'Arizona', 'code' => 'AZ', 'capital' => 'Phoenix'],
+            'AR' => ['name' => 'Arkansas', 'code' => 'AR', 'capital' => 'Little Rock'],
+            'CA' => ['name' => 'California', 'code' => 'CA', 'capital' => 'Sacramento'],
+            'CO' => ['name' => 'Colorado', 'code' => 'CO', 'capital' => 'Denver'],
+            'CT' => ['name' => 'Connecticut', 'code' => 'CT', 'capital' => 'Hartford'],
+            'DE' => ['name' => 'Delaware', 'code' => 'DE', 'capital' => 'Dover'],
+            'FL' => ['name' => 'Florida', 'code' => 'FL', 'capital' => 'Tallahassee'],
+            'GA' => ['name' => 'Georgia', 'code' => 'GA', 'capital' => 'Atlanta'],
+            'HI' => ['name' => 'Hawaii', 'code' => 'HI', 'capital' => 'Honolulu'],
+            'ID' => ['name' => 'Idaho', 'code' => 'ID', 'capital' => 'Boise'],
+            'IL' => ['name' => 'Illinois', 'code' => 'IL', 'capital' => 'Springfield'],
+            'IN' => ['name' => 'Indiana', 'code' => 'IN', 'capital' => 'Indianapolis'],
+            'IA' => ['name' => 'Iowa', 'code' => 'IA', 'capital' => 'Des Moines'],
+            'KS' => ['name' => 'Kansas', 'code' => 'KS', 'capital' => 'Topeka'],
+            'KY' => ['name' => 'Kentucky', 'code' => 'KY', 'capital' => 'Frankfort'],
+            'LA' => ['name' => 'Louisiana', 'code' => 'LA', 'capital' => 'Baton Rouge'],
+            'ME' => ['name' => 'Maine', 'code' => 'ME', 'capital' => 'Augusta'],
+            'MD' => ['name' => 'Maryland', 'code' => 'MD', 'capital' => 'Annapolis'],
+            'MA' => ['name' => 'Massachusetts', 'code' => 'MA', 'capital' => 'Boston'],
+            'MI' => ['name' => 'Michigan', 'code' => 'MI', 'capital' => 'Lansing'],
+            'MN' => ['name' => 'Minnesota', 'code' => 'MN', 'capital' => 'Saint Paul'],
+            'MS' => ['name' => 'Mississippi', 'code' => 'MS', 'capital' => 'Jackson'],
+            'MO' => ['name' => 'Missouri', 'code' => 'MO', 'capital' => 'Jefferson City'],
+            'MT' => ['name' => 'Montana', 'code' => 'MT', 'capital' => 'Helena'],
+            'NE' => ['name' => 'Nebraska', 'code' => 'NE', 'capital' => 'Lincoln'],
+            'NV' => ['name' => 'Nevada', 'code' => 'NV', 'capital' => 'Carson City'],
+            'NH' => ['name' => 'New Hampshire', 'code' => 'NH', 'capital' => 'Concord'],
+            'NJ' => ['name' => 'New Jersey', 'code' => 'NJ', 'capital' => 'Trenton'],
+            'NM' => ['name' => 'New Mexico', 'code' => 'NM', 'capital' => 'Santa Fe'],
+            'NY' => ['name' => 'New York', 'code' => 'NY', 'capital' => 'Albany'],
+            'NC' => ['name' => 'North Carolina', 'code' => 'NC', 'capital' => 'Raleigh'],
+            'ND' => ['name' => 'North Dakota', 'code' => 'ND', 'capital' => 'Bismarck'],
+            'OH' => ['name' => 'Ohio', 'code' => 'OH', 'capital' => 'Columbus'],
+            'OK' => ['name' => 'Oklahoma', 'code' => 'OK', 'capital' => 'Oklahoma City'],
+            'OR' => ['name' => 'Oregon', 'code' => 'OR', 'capital' => 'Salem'],
+            'PA' => ['name' => 'Pennsylvania', 'code' => 'PA', 'capital' => 'Harrisburg'],
+            'RI' => ['name' => 'Rhode Island', 'code' => 'RI', 'capital' => 'Providence'],
+            'SC' => ['name' => 'South Carolina', 'code' => 'SC', 'capital' => 'Columbia'],
+            'SD' => ['name' => 'South Dakota', 'code' => 'SD', 'capital' => 'Pierre'],
+            'TN' => ['name' => 'Tennessee', 'code' => 'TN', 'capital' => 'Nashville'],
+            'TX' => ['name' => 'Texas', 'code' => 'TX', 'capital' => 'Austin'],
+            'UT' => ['name' => 'Utah', 'code' => 'UT', 'capital' => 'Salt Lake City'],
+            'VT' => ['name' => 'Vermont', 'code' => 'VT', 'capital' => 'Montpelier'],
+            'VA' => ['name' => 'Virginia', 'code' => 'VA', 'capital' => 'Richmond'],
+            'WA' => ['name' => 'Washington', 'code' => 'WA', 'capital' => 'Olympia'],
+            'WV' => ['name' => 'West Virginia', 'code' => 'WV', 'capital' => 'Charleston'],
+            'WI' => ['name' => 'Wisconsin', 'code' => 'WI', 'capital' => 'Madison'],
+            'WY' => ['name' => 'Wyoming', 'code' => 'WY', 'capital' => 'Cheyenne'],
+            'DC' => ['name' => 'District of Columbia', 'code' => 'DC', 'capital' => 'Washington']
+        ];
+    }
+}

--- a/database/init.php
+++ b/database/init.php
@@ -99,6 +99,9 @@ try {
     echo "  MCP Server:  /mcp\n";
     echo "  MCP Registry:/mcp/registry\n";
 
+    // Ensure database is properly closed/flushed
+    R::close();
+
 } catch (\Exception $e) {
     echo "\n❌ Error: " . $e->getMessage() . "\n";
     exit(1);

--- a/scripts/run_map_migration.php
+++ b/scripts/run_map_migration.php
@@ -1,0 +1,60 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Run Map Permissions Migration
+ * Temporary script to insert authcontrol entries for the Map feature
+ *
+ * Usage: php run_map_migration.php
+ */
+
+// Ensure we're running from CLI
+if (php_sapi_name() !== 'cli') {
+    die("This script must be run from the command line\n");
+}
+
+// Load bootstrap
+require_once __DIR__ . '/../bootstrap.php';
+
+use \RedBeanPHP\R as R;
+
+// Colors for output
+define('GREEN', "\033[0;32m");
+define('YELLOW', "\033[1;33m");
+define('BLUE', "\033[0;34m");
+define('NC', "\033[0m"); // No Color
+
+echo BLUE . "\n=== Map Permissions Migration ===\n" . NC;
+
+try {
+    // Initialize application
+    $app = new \app\Bootstrap('conf/config.ini');
+
+    echo "\nAdding Map feature permissions...\n\n";
+
+    // Map USA page - public access
+    $entry1 = R::dispense('authcontrol');
+    $entry1->control = 'map';
+    $entry1->method = 'usa';
+    $entry1->level = 101;
+    $entry1->description = 'USA Map - Public access';
+    $entry1->createdAt = date('Y-m-d H:i:s');
+    R::store($entry1);
+    echo GREEN . "✓ Added: map::usa (level 101)" . NC . "\n";
+
+    // State details AJAX endpoint - public access
+    $entry2 = R::dispense('authcontrol');
+    $entry2->control = 'map';
+    $entry2->method = 'statedetails';
+    $entry2->level = 101;
+    $entry2->description = 'State Details API - Public access';
+    $entry2->createdAt = date('Y-m-d H:i:s');
+    R::store($entry2);
+    echo GREEN . "✓ Added: map::statedetails (level 101)" . NC . "\n";
+
+    echo "\n" . BLUE . "=== Migration Complete ===" . NC . "\n";
+    echo "Now run: " . YELLOW . "php scripts/resetcache.php" . NC . "\n\n";
+
+} catch (\Exception $e) {
+    echo "\n" . "\033[0;31m" . "Error: " . $e->getMessage() . NC . "\n\n";
+    exit(1);
+}

--- a/sql/map_permissions.sql
+++ b/sql/map_permissions.sql
@@ -1,0 +1,11 @@
+-- Map Feature Permissions
+-- Run: sqlite3 database/tiknix.db < sql/map_permissions.sql
+-- Or via MySQL: mysql -u user -p database < sql/map_permissions.sql
+
+-- Map USA page - public access
+INSERT OR REPLACE INTO authcontrol (control, method, level, description, created_at)
+VALUES ('map', 'usa', 101, 'USA Map - Public access', CURRENT_TIMESTAMP);
+
+-- State details AJAX endpoint - public access
+INSERT OR REPLACE INTO authcontrol (control, method, level, description, created_at)
+VALUES ('map', 'statedetails', 101, 'State Details API - Public access', CURRENT_TIMESTAMP);

--- a/views/map/usa.php
+++ b/views/map/usa.php
@@ -1,0 +1,218 @@
+<div class="container-fluid py-4">
+    <div class="row">
+        <div class="col-12">
+            <h1 class="mb-4"><i class="bi bi-geo-alt"></i> Map of the United States</h1>
+            <p class="lead text-muted">Click on any state to view details</p>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-body p-0">
+                    <div id="usa-map" style="height: 600px; width: 100%;"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- State Details Offcanvas -->
+<div class="offcanvas offcanvas-end" tabindex="-1" id="stateDetailsOffcanvas" aria-labelledby="stateDetailsLabel">
+    <div class="offcanvas-header">
+        <h5 class="offcanvas-title" id="stateDetailsLabel">
+            <span id="stateName">State Details</span>
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+    </div>
+    <div class="offcanvas-body">
+        <div id="stateLoading" class="text-center py-4">
+            <div class="spinner-border text-primary" role="status">
+                <span class="visually-hidden">Loading...</span>
+            </div>
+        </div>
+        <div id="stateContent" style="display: none;">
+            <div class="mb-4">
+                <span class="badge bg-primary fs-5 mb-3" id="stateCode"></span>
+                <h3 id="stateFullName"></h3>
+                <p class="text-muted"><strong>Capital:</strong> <span id="stateCapital"></span></p>
+            </div>
+
+            <hr>
+
+            <div class="state-info">
+                <h5>About This State</h5>
+                <p id="stateLorem">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+
+                <h5 class="mt-4">Key Facts</h5>
+                <ul class="list-group list-group-flush">
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                        Population
+                        <span class="badge bg-secondary rounded-pill">Loading...</span>
+                    </li>
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                        Area (sq mi)
+                        <span class="badge bg-secondary rounded-pill">Loading...</span>
+                    </li>
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                        Time Zone
+                        <span class="badge bg-secondary rounded-pill">Loading...</span>
+                    </li>
+                </ul>
+
+                <h5 class="mt-4">Description</h5>
+                <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+
+                <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.</p>
+            </div>
+        </div>
+        <div id="stateError" style="display: none;">
+            <div class="alert alert-danger">
+                <i class="bi bi-exclamation-triangle"></i>
+                <span id="stateErrorMessage">Failed to load state details.</span>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- jvectormap CSS -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsvectormap@1.6.0/dist/css/jsvectormap.min.css">
+
+<style>
+#usa-map {
+    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+    border-radius: 0.375rem;
+}
+
+.jvm-container {
+    touch-action: none;
+}
+
+.jvm-tooltip {
+    background: #333 !important;
+    color: #fff !important;
+    border-radius: 4px;
+    padding: 5px 10px;
+    font-size: 12px;
+}
+
+.offcanvas {
+    width: 400px !important;
+}
+
+.state-info h5 {
+    color: #6c757d;
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.75rem;
+}
+
+.list-group-item {
+    background: transparent;
+    border-color: rgba(255,255,255,0.1);
+}
+
+@media (max-width: 768px) {
+    #usa-map {
+        height: 400px !important;
+    }
+
+    .offcanvas {
+        width: 100% !important;
+    }
+}
+</style>
+
+<!-- jvectormap JS -->
+<script src="https://cdn.jsdelivr.net/npm/jsvectormap@1.6.0/dist/jsvectormap.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jsvectormap@1.6.0/dist/maps/us-merc.js"></script>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // State code mapping from jsvectormap to our format
+    const stateCodeMap = {
+        'US-AL': 'AL', 'US-AK': 'AK', 'US-AZ': 'AZ', 'US-AR': 'AR', 'US-CA': 'CA',
+        'US-CO': 'CO', 'US-CT': 'CT', 'US-DE': 'DE', 'US-FL': 'FL', 'US-GA': 'GA',
+        'US-HI': 'HI', 'US-ID': 'ID', 'US-IL': 'IL', 'US-IN': 'IN', 'US-IA': 'IA',
+        'US-KS': 'KS', 'US-KY': 'KY', 'US-LA': 'LA', 'US-ME': 'ME', 'US-MD': 'MD',
+        'US-MA': 'MA', 'US-MI': 'MI', 'US-MN': 'MN', 'US-MS': 'MS', 'US-MO': 'MO',
+        'US-MT': 'MT', 'US-NE': 'NE', 'US-NV': 'NV', 'US-NH': 'NH', 'US-NJ': 'NJ',
+        'US-NM': 'NM', 'US-NY': 'NY', 'US-NC': 'NC', 'US-ND': 'ND', 'US-OH': 'OH',
+        'US-OK': 'OK', 'US-OR': 'OR', 'US-PA': 'PA', 'US-RI': 'RI', 'US-SC': 'SC',
+        'US-SD': 'SD', 'US-TN': 'TN', 'US-TX': 'TX', 'US-UT': 'UT', 'US-VT': 'VT',
+        'US-VA': 'VA', 'US-WA': 'WA', 'US-WV': 'WV', 'US-WI': 'WI', 'US-WY': 'WY',
+        'US-DC': 'DC'
+    };
+
+    // Initialize the map
+    const map = new jsVectorMap({
+        selector: '#usa-map',
+        map: 'us_merc',
+        zoomOnScroll: true,
+        zoomButtons: true,
+        regionStyle: {
+            initial: {
+                fill: '#4a90d9',
+                stroke: '#1a1a2e',
+                strokeWidth: 0.5
+            },
+            hover: {
+                fill: '#67b26f',
+                cursor: 'pointer'
+            },
+            selected: {
+                fill: '#ffd700'
+            }
+        },
+        onRegionTooltipShow: function(event, tooltip, code) {
+            const stateCode = stateCodeMap[code] || code.replace('US-', '');
+            const states = <?= json_encode($states) ?>;
+            const state = states[stateCode];
+            if (state) {
+                tooltip.text(state.name);
+            }
+        },
+        onRegionClick: function(event, code) {
+            const stateCode = stateCodeMap[code] || code.replace('US-', '');
+            showStateDetails(stateCode);
+        }
+    });
+
+    // Show state details in offcanvas
+    function showStateDetails(stateCode) {
+        const offcanvas = new bootstrap.Offcanvas(document.getElementById('stateDetailsOffcanvas'));
+
+        // Show loading state
+        document.getElementById('stateLoading').style.display = 'block';
+        document.getElementById('stateContent').style.display = 'none';
+        document.getElementById('stateError').style.display = 'none';
+        document.getElementById('stateName').textContent = 'Loading...';
+
+        offcanvas.show();
+
+        // Fetch state details
+        fetch('/map/statedetails?state=' + stateCode)
+            .then(response => response.json())
+            .then(data => {
+                document.getElementById('stateLoading').style.display = 'none';
+
+                if (data.success && data.state) {
+                    document.getElementById('stateContent').style.display = 'block';
+                    document.getElementById('stateName').textContent = data.state.name;
+                    document.getElementById('stateFullName').textContent = data.state.name;
+                    document.getElementById('stateCode').textContent = data.state.code;
+                    document.getElementById('stateCapital').textContent = data.state.capital;
+                } else {
+                    document.getElementById('stateError').style.display = 'block';
+                    document.getElementById('stateErrorMessage').textContent = data.message || 'State not found';
+                }
+            })
+            .catch(error => {
+                document.getElementById('stateLoading').style.display = 'none';
+                document.getElementById('stateError').style.display = 'block';
+                document.getElementById('stateErrorMessage').textContent = 'Failed to load state details: ' + error.message;
+            });
+    }
+});
+</script>

--- a/views/map/usa.php
+++ b/views/map/usa.php
@@ -10,7 +10,7 @@
         <div class="col-12">
             <div class="card">
                 <div class="card-body p-0">
-                    <div id="usa-map" style="height: 600px; width: 100%;"></div>
+                    <div id="usa-map"></div>
                 </div>
             </div>
         </div>
@@ -79,6 +79,17 @@
 #usa-map {
     background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
     border-radius: 0.375rem;
+    /* Responsive height: fill available viewport space minus header/nav area */
+    height: calc(100vh - 250px);
+    min-height: 300px;
+    max-height: 800px;
+    width: 100%;
+}
+
+/* Ensure SVG inside scales properly */
+#usa-map svg {
+    width: 100% !important;
+    height: 100% !important;
 }
 
 .datamaps-hoverover {
@@ -109,13 +120,32 @@
     border-color: rgba(255,255,255,0.1);
 }
 
-@media (max-width: 768px) {
+/* Tablet and smaller screens */
+@media (max-width: 992px) {
     #usa-map {
-        height: 400px !important;
+        height: calc(100vh - 200px);
+        min-height: 250px;
+    }
+}
+
+/* Mobile screens */
+@media (max-width: 576px) {
+    #usa-map {
+        height: calc(100vh - 180px);
+        min-height: 200px;
+        max-height: 400px;
     }
 
     .offcanvas {
         width: 100% !important;
+    }
+}
+
+/* Landscape mobile - prioritize width */
+@media (max-height: 500px) and (orientation: landscape) {
+    #usa-map {
+        height: calc(100vh - 120px);
+        min-height: 150px;
     }
 }
 </style>
@@ -184,6 +214,12 @@ document.addEventListener('DOMContentLoaded', function() {
                     document.getElementById('stateFullName').textContent = data.state.name;
                     document.getElementById('stateCode').textContent = data.state.code;
                     document.getElementById('stateCapital').textContent = data.state.capital;
+
+                    // Populate Key Facts with placeholder data
+                    var badges = document.querySelectorAll('#stateContent .badge.bg-secondary');
+                    if (badges[0]) badges[0].textContent = 'N/A';
+                    if (badges[1]) badges[1].textContent = 'N/A';
+                    if (badges[2]) badges[2].textContent = 'N/A';
                 } else {
                     document.getElementById('stateError').style.display = 'block';
                     document.getElementById('stateErrorMessage').textContent = data.message || 'State not found';


### PR DESCRIPTION
## Summary
- Add interactive map of the USA at `/map/usa` using DataMaps (D3.js)
- Clicking any state opens a Bootstrap offcanvas slide-out showing state name, code, capital, and placeholder content
- AJAX endpoint at `/map/statedetails` returns state data as JSON
- Responsive design with media queries for tablet, mobile, and landscape orientations
- Includes authcontrol migration script for PUBLIC (101) access

## Files Changed
- `controls/Map.php` - Map controller with `usa()` and `stateDetails()` methods
- `views/map/usa.php` - Map view with DataMaps, offcanvas panel, and responsive CSS
- `sql/map_permissions.sql` - SQL migration for authcontrol entries
- `scripts/run_map_migration.php` - PHP migration script
- `bootstrap.php` - Fix config path resolution for CLI scripts
- `database/init.php` - Ensure DB connection is closed after init

## Test plan
- [ ] Navigate to `/map/usa` and verify the map renders
- [ ] Hover over states to see tooltips
- [ ] Click a state to open the slide-out panel
- [ ] Verify state name, code badge, and capital display correctly
- [ ] Test on mobile viewport to verify responsive behavior
- [ ] Run `php scripts/run_map_migration.php` to add authcontrol permissions